### PR TITLE
Issues optional relations

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,15 @@
   "name": "nuxt-redmine",
   "version": "0.0.2",
   "description": "Redmine REST API integration for Nuxt",
+  "keywords": [
+    "redmine",
+    "nuxt",
+    "nuxt-api",
+    "nuxt-module",
+    "issue-tracking",
+    "project-management"
+  ],
+  "author": "Vsevolod Girenko <vs.girenko@mail.ru>",
   "repository": "https://github.com/sauromates/nuxt-redmine",
   "bugs": "https://github.com/sauromates/nuxt-redmine/issues",
   "license": "MIT",

--- a/src/runtime/models/attachment.ts
+++ b/src/runtime/models/attachment.ts
@@ -1,0 +1,13 @@
+export type RedmineAttachment = {
+  id: number
+  filename: string
+  filesize: number
+  content_type: string
+  description?: string
+  content_url: string
+  author: {
+    id: number
+    name: string
+  }
+  created_on: Date | string
+}

--- a/src/runtime/models/issue.ts
+++ b/src/runtime/models/issue.ts
@@ -4,6 +4,7 @@ import type { RedmineIssuePriority } from './priority'
 import type { RedmineProject } from './project'
 import type { RedmineTracker } from './tracker'
 import type { RedmineVersion } from './version'
+import type { RedmineAttachment } from './attachment'
 
 export type RedmineIssue = {
   id?: number
@@ -29,6 +30,7 @@ export type RedmineIssue = {
   created_on: Date
   updated_on: Date
   closed_on: Date | null
+  attachments?: RedmineAttachment[]
 }
 
 export type RealRedmineIssue = RedmineIssue & {

--- a/src/runtime/models/issue.ts
+++ b/src/runtime/models/issue.ts
@@ -5,6 +5,8 @@ import type { RedmineProject } from './project'
 import type { RedmineTracker } from './tracker'
 import type { RedmineVersion } from './version'
 import type { RedmineAttachment } from './attachment'
+import type { RedmineJournal } from './journal'
+import type { RedmineIssueRelation } from './relation'
 
 export type RedmineIssue = {
   id?: number
@@ -14,7 +16,7 @@ export type RedmineIssue = {
   tracker: Partial<Pick<RedmineTracker, 'id' | 'name'>>
   status: RedmineIssueStatus
   priority?: Partial<Pick<RedmineIssuePriority, 'id' | 'name'>>
-  parent?: Pick<RedmineIssue, 'id' | 'subject'>
+  parent?: Pick<RedmineIssue, 'id'>
   author: { id: number; name: string }
   assigned_to?: { id: number; name: string }
   category?: Partial<Pick<RedmineIssueCategory, 'id' | 'name'>>
@@ -30,7 +32,12 @@ export type RedmineIssue = {
   created_on: Date
   updated_on: Date
   closed_on: Date | null
+  watchers: { id: number; name: string }[]
   attachments?: RedmineAttachment[]
+  allowed_statuses?: RedmineIssueStatus[]
+  children?: Pick<RedmineIssue, 'id' | 'tracker' | 'subject'>[]
+  journals?: RedmineJournal[]
+  relations?: RedmineIssueRelation[]
 }
 
 export type RealRedmineIssue = RedmineIssue & {

--- a/src/runtime/models/issue.ts
+++ b/src/runtime/models/issue.ts
@@ -3,7 +3,6 @@ import type { RedmineIssueStatus } from './status'
 import type { RedmineIssuePriority } from './priority'
 import type { RedmineProject } from './project'
 import type { RedmineTracker } from './tracker'
-import type { RedmineUser } from './user'
 import type { RedmineVersion } from './version'
 
 export type RedmineIssue = {
@@ -15,8 +14,8 @@ export type RedmineIssue = {
   status: RedmineIssueStatus
   priority?: Partial<Pick<RedmineIssuePriority, 'id' | 'name'>>
   parent?: Pick<RedmineIssue, 'id' | 'subject'>
-  author: Partial<Pick<RedmineUser, 'id' | ('firstname' & 'lastname')>>
-  assigned_to?: Partial<Pick<RedmineUser, 'id' | ('firstname' & 'lastname')>>
+  author: { id: number; name: string }
+  assigned_to?: { id: number; name: string }
   category?: Partial<Pick<RedmineIssueCategory, 'id' | 'name'>>
   fixed_version?: Partial<Pick<RedmineVersion, 'id' | 'name'>>
   done_ratio: number

--- a/src/runtime/models/journal.ts
+++ b/src/runtime/models/journal.ts
@@ -1,0 +1,17 @@
+export type RedmineJournalEntry = {
+  property: 'attr' | 'attachment' | 'relation'
+  name: string
+  old_value: string | null | boolean
+  new_value: string | null | boolean
+}
+
+export type RedmineJournal = {
+  id: number
+  user: {
+    id: number
+    name: string
+  }
+  notes: string
+  private_notes: boolean
+  details: RedmineJournalEntry[]
+}

--- a/src/runtime/models/relation.ts
+++ b/src/runtime/models/relation.ts
@@ -1,0 +1,9 @@
+export type RedmineIssueRelationType = 'relates' | 'duplicates' | 'blocks' | 'precedes' | 'copied_to'
+
+export type RedmineIssueRelation = {
+  id: number
+  issue_id: number
+  issue_to_id: number
+  relation_type: RedmineIssueRelationType
+  delay: number | null
+}

--- a/src/runtime/types/requests/issues/showIssue.ts
+++ b/src/runtime/types/requests/issues/showIssue.ts
@@ -4,7 +4,6 @@ export type RedmineIssueRelation =
   | 'children'
   | 'attachments'
   | 'relations'
-  | 'changesets'
   | 'journals'
   | 'watchers'
   | 'allowed_statuses'

--- a/src/runtime/types/requests/issues/showIssue.ts
+++ b/src/runtime/types/requests/issues/showIssue.ts
@@ -1,6 +1,6 @@
 import type { RedmineRequest } from '../request'
 
-export type RedmineIssueRelation =
+export type RedmineIssueIncludedRelation =
   | 'children'
   | 'attachments'
   | 'relations'
@@ -15,6 +15,6 @@ export type RedmineIssueRelation =
  */
 export type ShowRedmineIssue = Omit<RedmineRequest, 'body'> & {
   query?: {
-    include?: RedmineIssueRelation | RedmineIssueRelation[]
+    include?: RedmineIssueIncludedRelation | RedmineIssueIncludedRelation[]
   }
 }


### PR DESCRIPTION
This PR introduces types for all issue-related models available for including via `GET /api/redmine/issues/[id].get.ts`.

Available options are listed in corresponding [request type](https://github.com/sauromates/nuxt-redmine/blob/main/src/runtime/types/requests/issues/showIssue.ts).


```ts
export type RedmineIssueIncludedRelation =
  | 'children'
  | 'attachments'
  | 'relations'
  | 'journals'
  | 'watchers'
  | 'allowed_statuses'
```